### PR TITLE
use HTTPS

### DIFF
--- a/lib/omniauth/strategies/draugiem.rb
+++ b/lib/omniauth/strategies/draugiem.rb
@@ -35,12 +35,12 @@ module OmniAuth
           :hash => Digest::MD5.hexdigest("#{options.api_key}#{callback_url}")
         }
         query_string = params.collect{ |key,value| "#{key}=#{Rack::Utils.escape(value)}" }.join('&')
-        redirect "http://api.draugiem.lv/authorize/?#{query_string}"
+        redirect "https://api.draugiem.lv/authorize/?#{query_string}"
       end
 
       def callback_phase
         if request.params['dr_auth_status'] == 'ok' && request.params['dr_auth_code']
-          response = RestClient.get('http://api.draugiem.lv/json/', { :params => draugiem_authorize_params(request.params['dr_auth_code']) })
+          response = RestClient.get('https://api.draugiem.lv/json/', { :params => draugiem_authorize_params(request.params['dr_auth_code']) })
           auth = MultiJson.decode(response.to_s)
           unless auth['error']
             @auth_data = auth


### PR DESCRIPTION
Safari v10 does not redirect to draugiem and throws the follwing error if using http://api.draugiem.lv

[blocked] The page at https://example.com/auth/draugiem was not allowed to display insecure content from http://api.draugiem.lv/authorize/?app=xxx&redirect=xxx&hash=xxx
